### PR TITLE
Makefile: implement GNU Coding Standard for Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ OUT := rmtfs
 
 CFLAGS := -Wall -g -I../qrtr/lib
 LDFLAGS := -L../qrtr -lqrtr
+prefix := /usr/local
 
 SRCS := qmi_rmtfs.c qmi_tlv.c rmtfs.c sharedmem.c storage.c util.c
 OBJS := $(SRCS:.c=.o)
@@ -12,8 +13,8 @@ $(OUT): $(OBJS)
 %.c: %.qmi
 	qmic < $<
 
-test: $(OUT)
-	./$(OUT)
+install: $(OUT)
+	install -D -m 755 $< $(DESTDIR)$(prefix)/bin/$<
 
 clean:
 	rm -f $(OUT) $(OBJS)


### PR DESCRIPTION
GNU coding standards notably specifies:
 * install files with the $(DESTDIR) to the target system image
 * install files with the $(prefix), not $(PREFIX)
 * the default value of $(prefix) should be /usr/local

as per
https://www.gnu.org/prep/standards/html_node/Directory-Variables.html.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>