### PR TITLE
sharedmem: support uio device (downstream kernels)

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -84,7 +84,7 @@ found:
 	if (fd < 0) {
 		saved_errno = errno;
 		fprintf(stderr, "[storage] failed to open '%s' (requested '%s'): %s\n",
-				part->actual, part->path, strerror(-errno));
+				part->actual, part->path, strerror(saved_errno));
 		return -saved_errno;
 	}
 


### PR DESCRIPTION
I don't know if you'll want this, since you're mainly targeting mainline kernels. Older downstream kernels seem to have a uio device for rmtfs, and no device tree info about it.

I tested on Samsung Galaxy S4 Mini LTE with [android_kernel_samsung_msm8930-common](https://github.com/LineageOS/android_kernel_samsung_msm8930-common) (cm-14.1 branch), with [libqipcrtr4msmipc](https://github.com/scintill/libqipcrtr4msmipc) emulating the IPC sockets. I don't have a mainline kernel to test with to make sure that still works.

This is presuming the system symlinks /dev/qcom_rmtfs_mem1 to the uio device, which might be bad form (udev man page says "Symlink names must never conflict with the kernel's default device node names", although a system that would make this a uio symlink would *not* have an actual qcom_rmtfs_mem1 node, so it should be OK?)