### PR TITLE
rmtfs: fix the type of the phys_address argument of rmtfs_mem_ptr()

### DIFF
--- a/sharedmem.c
+++ b/sharedmem.c
@@ -261,7 +261,7 @@ void rmtfs_mem_free(struct rmtfs_mem *rmem)
 {
 }
 
-static void *rmtfs_mem_ptr(struct rmtfs_mem *rmem, unsigned phys_address, ssize_t len)
+static void *rmtfs_mem_ptr(struct rmtfs_mem *rmem, unsigned long phys_address, ssize_t len)
 {
 	uint64_t start;
 	uint64_t end;


### PR DESCRIPTION
The 'phys_address' argument of rmtfs_mem_read() and rmtfs_mem_write() is
an 'unsigned long' type value, which is then passed to the
'phys_address' argument of rmtfs_mem_ptr(), which is an 'unsigned int'
type value. This patch fixes the mismatch.

Signed-off-by: Ben Chan <benchan@chromium.org>