### PR TITLE
rmtfs: remove unused cpu_to_le32 and le32_to_cpu functions

### DIFF
--- a/rmtfs.c
+++ b/rmtfs.c
@@ -21,9 +21,6 @@
 #define RMTFS_QMI_VERSION	1
 #define RMTFS_QMI_INSTANCE	0
 
-static inline __le32 cpu_to_le32(uint32_t x) { return htole32(x); }
-static inline uint32_t le32_to_cpu(__le32 x) { return le32toh(x); }
-
 static struct rmtfs_mem *rmem;
 
 static bool dbgprintf_enabled;


### PR DESCRIPTION
This patch addresses the following compiler warnings on unused function:

  rmtfs.c:24:22: warning: unused function 'cpu_to_le32' [-Wunused-function]
  static inline __le32 cpu_to_le32(uint32_t x) { return htole32(x); }
                       ^
  rmtfs.c:25:24: warning: unused function 'le32_to_cpu' [-Wunused-function]
  static inline uint32_t le32_to_cpu(__le32 x) { return le32toh(x); }
                       ^