### PR TITLE
storage: configure directory at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ CFLAGS += -Wall -g -O2
 LDFLAGS += -lqrtr -ludev
 prefix = /usr/local
 
+RMTFS_DIR = /boot
+
+CFLAGS += -DRMTFS_DIR=\"$(RMTFS_DIR)\"
+
 SRCS := qmi_rmtfs.c rmtfs.c sharedmem.c storage.c util.c
 OBJS := $(SRCS:.c=.o)
 

--- a/storage.c
+++ b/storage.c
@@ -23,10 +23,10 @@ struct caller {
 };
 
 static const struct partition partition_table[] = {
-	{ "/boot/modem_fs1", "/boot/modem_fs1" },
-	{ "/boot/modem_fs2", "/boot/modem_fs2" },
-	{ "/boot/modem_fsc", "/boot/modem_fsc" },
-	{ "/boot/modem_fsg", "/boot/modem_fsg" },
+	{ "/boot/modem_fs1", RMTFS_DIR "/modem_fs1" },
+	{ "/boot/modem_fs2", RMTFS_DIR "/modem_fs2" },
+	{ "/boot/modem_fsc", RMTFS_DIR "/modem_fsc" },
+	{ "/boot/modem_fsg", RMTFS_DIR "/modem_fsg" },
 	{}
 };
 


### PR DESCRIPTION
Storage shouldn't be fixed to the /boot directory; the location should
be up to the distribution.

This supports: make RMTFS_DIR=/var/some/other/path

Signed-off-by: Brian Norris <briannorris@chromium.org>