### PR TITLE
Support for file-backed EFS

### DIFF
--- a/rmtfs.c
+++ b/rmtfs.c
@@ -188,10 +188,15 @@ static void rmtfs_iovec(int sock, struct qrtr_packet *pkt)
 		for (j = 0; j < entries[i].num_sector; j++) {
 			if (is_write) {
 				n = rmtfs_mem_read(rmem, phys_offset, buf, SECTOR_SIZE);
-				n = write(fd, buf, n);
+				if (n == SECTOR_SIZE)
+					n = write(fd, buf, n);
 			} else {
 				n = read(fd, buf, SECTOR_SIZE);
-				n = rmtfs_mem_write(rmem, phys_offset, buf, n);
+				if (n >= 0) {
+					if (n < SECTOR_SIZE)
+						memset(buf + n, 0, SECTOR_SIZE - n);
+					n = rmtfs_mem_write(rmem, phys_offset, buf, SECTOR_SIZE);
+				}
 			}
 
 			if (n != SECTOR_SIZE) {

--- a/rmtfs.c
+++ b/rmtfs.c
@@ -448,15 +448,32 @@ static int run_rmtfs(void)
 int main(int argc, char **argv)
 {
 	int ret;
+	int option;
+	const char *storage_root = NULL;
 
-	if (argc == 2 && strcmp(argv[1], "-v") == 0)
-		dbgprintf_enabled = true;
+	while ((option = getopt(argc, argv, "o:v")) != -1) {
+		switch (option) {
+		/* -o sets the directory where EFS images are stored. */
+		case 'o':
+			storage_root = optarg;
+			break;
+
+		/* -v is for verbose */
+		case 'v':
+			dbgprintf_enabled = 1;
+			break;
+
+		case '?':
+			fprintf(stderr, "Unknown option: -%c\n", option);
+			return 1;
+		}
+	}
 
 	rmem = rmtfs_mem_open();
 	if (!rmem)
 		return 1;
 
-	ret = storage_open();
+	ret = storage_open(storage_root);
 	if (ret) {
 		fprintf(stderr, "failed to initialize storage system\n");
 		goto close_rmtfs_mem;

--- a/rmtfs.h
+++ b/rmtfs.h
@@ -23,7 +23,7 @@ void rmtfs_mem_free(struct rmtfs_mem *rmem);
 ssize_t rmtfs_mem_read(struct rmtfs_mem *rmem, unsigned long phys_address, void *buf, ssize_t len);
 ssize_t rmtfs_mem_write(struct rmtfs_mem *rmem, unsigned long phys_address, const void *buf, ssize_t len);
 
-int storage_open(void);
+int storage_open(const char *storage_root);
 int storage_get(unsigned node, const char *path);
 int storage_put(unsigned node, int caller_id);
 int storage_get_handle(unsigned node, int caller_id);


### PR DESCRIPTION
These changes enable better support for backing the EFS images via regular file system files, rather than partitions.

The first change enables EFS images that size automatically when they're written. This will be very useful when trying to create a minimal FSG.

The second change allows specifying an output directory other than /boot for the images. I saw Brian posted a version of this, but thought this way might be a little more friendly.