### PR TITLE
rmtfs.c: Exit when fail to get rprocfd

### DIFF
--- a/rmtfs.c
+++ b/rmtfs.c
@@ -517,6 +517,11 @@ int main(int argc, char **argv)
 		/* enable sync for the mss rproc instance */
 		case 's':
 			rprocfd = rproc_init();
+			if (rprocfd < 0) {
+				fprintf(stderr, "Failed to get rprocfd\n");
+				return 1;
+			}
+
 			break;
 
 		/* -v is for verbose */


### PR DESCRIPTION
When -s option is specified rmtfs handled the start of rproc
but at init may be the /sys entries are not fully populated yet
due to module load/setup so exit with 1 and let systemd restart
the service.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>