### PR TITLE
rmtfs.service.in: Add RestartSec to 1 sec intervals

### DIFF
--- a/rmtfs.service.in
+++ b/rmtfs.service.in
@@ -6,6 +6,7 @@ After=qrtr-ns.service
 [Service]
 ExecStart=RMTFS_PATH/rmtfs -r -P -s
 Restart=always
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Systemd has a default restart policy of 5 retries so wait
1 second in each retry because if is too fast will fail to
start properly.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>