### PR TITLE
storage: Add modem_tunning partition needed for Alcatel Idol 3 devices

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -41,6 +41,7 @@ static const struct partition partition_table[] = {
 	{ "/boot/modem_fs2", "modem_fs2", "modemst2" },
 	{ "/boot/modem_fsc", "modem_fsc", "fsc" },
 	{ "/boot/modem_fsg", "modem_fsg", "fsg" },
+	{ "/boot/modem_tunning", "modem_tunning", "tunning" },
 	{}
 };
 


### PR DESCRIPTION
This additional partition is required to bring up modem
on msm8916 and msm8939 based Idol 3 phones.