### PR TITLE
Add "modem_tng" alias for tunning partition

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -42,6 +42,7 @@ static const struct partition partition_table[] = {
 	{ "/boot/modem_fsc", "modem_fsc", "fsc" },
 	{ "/boot/modem_fsg", "modem_fsg", "fsg" },
 	{ "/boot/modem_tunning", "modem_tunning", "tunning" },
+	{ "/boot/modem_tng", "modem_tng", "tunning" },
 	{}
 };
 


### PR DESCRIPTION
Some devices (e.g., the Nokia 8110 4G with msm8905) use the name `modem_tng` for the `tunning` partition instead of `modem_tunning` as in #12 . See also: https://git.abscue.de/bananian/rmtfs/-/blob/devel/debian/patches/0001-bananian-support-nokia-8110.patch