### PR TITLE
storage: Try opening the slot-suffixed partition

### DIFF
--- a/rmtfs.h
+++ b/rmtfs.h
@@ -26,7 +26,8 @@ ssize_t rmtfs_mem_write(struct rmtfs_mem *rmem, unsigned long phys_address, cons
 struct rmtfd;
 
 int storage_init(const char *storage_root, bool read_only, bool use_partitions);
-struct rmtfd *storage_open(unsigned node, const char *path);
+#define SLOT_SUFFIX_LEN	(2 + 1) /* "_a" or "_b", null-terminated */
+struct rmtfd *storage_open(unsigned node, const char *path, const char *slot_suffix);
 struct rmtfd *storage_get(unsigned node, int caller_id);
 void storage_close(struct rmtfd *rmtfd);
 int storage_get_caller_id(const struct rmtfd *rmtfd);


### PR DESCRIPTION
Some devices ship 2 copies of remote partitions (see e.g. #22), which the current code can't cope with.

Add parsing of a slot suffix (via '-S', single character) and if passed, retry opening partition (via a partlabel) with it.