### PR TITLE
rmtfs: Fix command line argument parsing for '-o' optarg

### DIFF
--- a/rmtfs.c
+++ b/rmtfs.c
@@ -505,7 +505,7 @@ int main(int argc, char **argv)
 	int option;
 	const char *storage_root = NULL;
 
-	while ((option = getopt(argc, argv, "oS:Prsv")) != -1) {
+	while ((option = getopt(argc, argv, "o:S:Prsv")) != -1) {
 		switch (option) {
 		/*
 		 * -o sets the directory where EFS images are stored,


### PR DESCRIPTION
Commit 2ee01bf ("storage: Try opening the slot-suffixed partition") introduced a bug where option '-o' is incorrectly specified as having no argument. Therefore, passing -o with a path incorrectly sets that path to the default '/boot' one as optarg evaluates to NULL. Fix this by telling getopt that we expect an argument.

Fixes: 2ee01bf ("storage: Try opening the slot-suffixed partition")