### PR TITLE
rmtfs: add OnePlus/Oppo OEM NV partition mappings

### DIFF
--- a/storage.c
+++ b/storage.c
@@ -44,6 +44,11 @@ static const struct partition partition_table[] = {
 	{ "/boot/modem_study", "modem_study", "study" },
 	{ "/boot/modem_tunning", "modem_tunning", "tunning" },
 	{ "/boot/modem_tng", "modem_tng", "tunning" },
+	/* OnePlus/Oppo OEM NV backup partitions */
+	{ "/oem/nvbk/static", "oem_stanvbk", "oem_stanvbk" },
+	{ "/oem/nvbk/dynamic", "oem_dycnvbk", "oem_dycnvbk" },
+	/* Some OxygenOS firmware versions request this alternative path */
+	{ "/oppo/oem_partion", "oem_stanvbk", "oem_stanvbk" },
 	{}
 };
 


### PR DESCRIPTION
OnePlus and Oppo devices with Qualcomm modems request OEM NV backup
partitions at `/oem/nvbk/static` and `/oem/nvbk/dynamic`. Without these
mappings in rmtfs, the modem crashes approximately 40 seconds after boot
when it fails to access the OEM NV data.

The partitions map to the `oem_stanvbk` and `oem_dycnvbk` partlabels
which are present on OnePlus/Oppo devices.

Some OxygenOS firmware versions also request `/oppo/oem_partion` (note:
the spelling is from the firmware) which maps to the same `oem_stanvbk`
partition.

**Testing:** OnePlus 7T (hotdogb) running postmarketOS with kernel 6.17,
Qualcomm SM8150, OxygenOS Android 10 modem firmware. Modem stable with
these mappings, crashes after ~40s without them.