### PR TITLE
rmtfs.service: Only start if dev node present

### DIFF
--- a/rmtfs.service.in
+++ b/rmtfs.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Qualcomm remotefs service
 Before=NetworkManager.service
+ConditionPathExists=/dev/qcom_rmtfs_mem1
 
 [Service]
 ExecStart=RMTFS_PATH/rmtfs -r -P -s


### PR DESCRIPTION
Allow having the rmtfs service present but not started on devices
which don't have a /dev/qcom_rmtfs_mem1 by starting only if this
node is present. This allows creating generic images, without
reporting an error because the service can't start when the device
node is lacking.

Fixes: #34
