### PR TITLE
rmtfs: start service after qcom_rmtfs_mem* device is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ LDFLAGS += -lqrtr -ludev -lpthread
 prefix = /usr/local
 bindir := $(prefix)/bin
 servicedir := $(prefix)/lib/systemd/system
+rulesdir := $(prefix)/lib/udev/rules.d
 
 RMTFS_EFS_PATH ?= /var/lib/rmtfs
 
@@ -24,8 +25,8 @@ install: $(OUT) rmtfs.service rmtfs-dir.service
 	@install -D -m 755 $(OUT) $(DESTDIR)$(prefix)/bin/$(OUT)
 	@install -D -m 644 rmtfs.service $(DESTDIR)$(servicedir)/rmtfs.service
 	@install -D -m 644 rmtfs-dir.service $(DESTDIR)$(servicedir)/rmtfs-dir.service
+	@install -D -m 644 rmtfs.rules $(DESTDIR)$(rulesdir)/rmtfs.rules
 
 clean:
 	rm -f $(OUT) $(OBJS) rmtfs.service
 	rm -f $(OUT) $(OBJS) rmtfs-dir.service
-

--- a/rmtfs.rules
+++ b/rmtfs.rules
@@ -1,0 +1,10 @@
+# Trigger rmtfs.service when the qcom_rmtfs_mem device node appears.
+#
+# /dev/qcom_rmtfs_mem* is created by the rmtfs-mem kernel module when the
+# modem shared-memory region is probed.  The exact boot time at which this
+# happens depends on whether the module is built-in or loaded as a module and
+# on the systemd target ordering, so a static ConditionPathExists check in the
+# service unit is not sufficient – the service must be (re-)triggered by udev
+# whenever the device shows up.
+
+ACTION=="add", KERNEL=="qcom_rmtfs_mem*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="rmtfs.service"


### PR DESCRIPTION
rmtfs.service fails to run with pull #35 when creation of the qcom_rmtfs_mem* device is delayed.

Update the startup flow to trigger the service only after the qcom_rmtfs_mem* node becomes available, using udev rules.

The current change along with https://github.com/linux-msm/rmtfs/pull/35 changes fixes below issue.

Fixes: https://github.com/linux-msm/rmtfs/issues/34